### PR TITLE
more gentle error handling

### DIFF
--- a/semver/tests/test_max_satisfying.py
+++ b/semver/tests/test_max_satisfying.py
@@ -27,4 +27,4 @@ def test_it(versions, range_, expect, loose, include_prerelease):
         with pytest.raises(expect):
             max_satisfying(versions, range_, loose, include_prerelease)
     else:
-      assert max_satisfying(versions, range_, loose, include_prerelease) == expect
+        assert max_satisfying(versions, range_, loose, include_prerelease) == expect

--- a/semver/tests/test_passing_bytes.py
+++ b/semver/tests/test_passing_bytes.py
@@ -1,0 +1,30 @@
+import pytest
+
+
+def test_max_satisfying():
+    def _callFUT(versions, range_):
+        from semver import max_satisfying
+        max_satisfying(versions, range_)
+
+    from semver import InvalidTypeIncluded
+    with pytest.raises(InvalidTypeIncluded):
+        _callFUT([b"1.0.0"], "1.0.0")
+    with pytest.raises(InvalidTypeIncluded):
+        _callFUT(["1.0.0"], b"1.0.0")
+    with pytest.raises(InvalidTypeIncluded):
+        _callFUT("1.0.0", [b"1.0.0"])  # mistakes
+    with pytest.raises(InvalidTypeIncluded):
+        _callFUT(b"1.0.0", ["1.0.0"])  # mistakes
+    _callFUT(["1.0.0"], "1.0.0")
+
+
+def test_satisfies():
+    def _callFUT(versions, range_):
+        from semver import satisfies
+        satisfies(versions, range_)
+
+    from semver import InvalidTypeIncluded
+    with pytest.raises(InvalidTypeIncluded):
+        _callFUT(b"1.0.0", "1.0.0")
+    with pytest.raises(InvalidTypeIncluded):
+        _callFUT("1.0.0", b"1.0.0")

--- a/semver/tests/test_passing_bytes.py
+++ b/semver/tests/test_passing_bytes.py
@@ -19,9 +19,9 @@ def test_max_satisfying():
 
 
 def test_satisfies():
-    def _callFUT(versions, range_):
+    def _callFUT(version, range_):
         from semver import satisfies
-        satisfies(versions, range_)
+        satisfies(version, range_)
 
     from semver import InvalidTypeIncluded
     with pytest.raises(InvalidTypeIncluded):


### PR DESCRIPTION
#26 

This is ad hoc fix. 

- adding InvalidTypeIncluded (exception)
- more strict error handling (don't catching Exception)

```python
from semver import max_satisfying

print(max_satisfying([b"1.0.0"], "1.0.0"))
# semver.InvalidTypeIncluded: must be str, but b'1.0.0'
```

----

(typing (#27) is more better, conceptually?)
