### PR TITLE
Pre release range fix

### DIFF
--- a/semver/__init__.py
+++ b/semver/__init__.py
@@ -286,7 +286,7 @@ def clean(version, loose):
 NUMERIC = re.compile(r"^\d+$")
 
 
-def semver(version, loose):
+def semver(version, loose, include_prerelease=False):
     if isinstance(version, SemVer):
         if version.loose == loose:
             return version
@@ -299,7 +299,7 @@ def semver(version, loose):
     if (!(this instanceof SemVer))
        return new SemVer(version, loose);
     """
-    return SemVer(version, loose)
+    return SemVer(version, loose, include_prerelease)
 
 
 make_semver = semver
@@ -308,9 +308,10 @@ make_semver = semver
 class SemVer(object):
     # major, minor, patch, prerelease, build, micro_version
 
-    def __init__(self, version, loose):
+    def __init__(self, version, loose, include_prerelease):
         logger.debug("SemVer %s, %s", version, loose)
         self.loose = loose
+        self.include_prerelease = include_prerelease
         self.raw = version
         self.micro_versions = []
         self.build = []
@@ -407,6 +408,9 @@ class SemVer(object):
     def compare_pre(self, other):
         if not isinstance(other, SemVer):
             other = make_semver(other, self.loose)
+
+        if self.include_prerelease:
+            return 0
 
         #  NOT having a prerelease is > having one
         is_self_more_than_zero = len(self.prerelease) > 0
@@ -811,7 +815,7 @@ class Range(object):
             return False
 
         if isinstance(version, str):
-            version = make_semver(version, loose=self.loose)
+            version = make_semver(version, loose=self.loose, include_prerelease=include_prerelease)
 
         for e in self.set:
             if test_set(e, version, include_prerelease=include_prerelease):

--- a/semver/tests/test_max_satisfying.py
+++ b/semver/tests/test_max_satisfying.py
@@ -15,7 +15,47 @@ cands = [
     [['1.1.0', '1.2.0', '1.2.1', '1.3.0', '2.0.0b1', '2.0.0b2', '2.0.0', '2.0.1b1', '2.1.0'], '~2.0.0', '2.0.0',
      True, False],
     [['1.1.0', '1.2.0', '1.2.1', '1.3.0', '2.0.0b1', '2.0.0b2', '2.0.0', '2.0.1b1', '2.1.0'], '~2.0.0', '2.0.1b1',
-     True, True]
+     True, True],
+
+    [['1.0.1-beta'], '1.x', None, False, False],
+    [['1.0.1-beta'], '1.x', '1.0.1-beta', False, True],
+    [['1.0.0-beta'], '1.x', '1.0.0-beta', False, True],
+    [['1.1.0-beta'], '1.0.x', None, False, True],
+    [['1.0.0-beta', '1.1.0-beta', '1.1.0'], '1.0.x', None, False, False],
+    [['1.0.0-beta', '1.1.0-beta', '1.1.0'], '1.0.x', '1.0.0-beta', False, True],
+
+    # testing with range '>' and '<'
+    [['1.0.0-beta', '1.0.0', '1.0.1-beta', '1.0.2-beta'], '>1.0.0 <1.0.2', None, False, False],
+    [['1.0.0-beta', '1.0.0', '1.0.1-beta', '1.0.2-beta'], '>1.0.0 <1.0.2', '1.0.1-beta', False, True],
+    [['1.0.0-beta', '1.0.0', '1.0.1', '1.1.0-beta', '1.1.0'], '>1.0.0 <1.1.0', '1.0.1', False, False],
+    [['1.0.0-beta', '1.0.0', '1.0.1', '1.1.0-beta', '1.1.0'], '>1.0.0 <1.1.0', '1.0.1', False, True],
+    [['1.0.0-beta', '1.1.0-beta'], '>1.0.0 <1.1.0', None, False, True],
+
+    # testing with range '>=' and '<=' and '<'
+    [['1.0.0-beta', '1.1.0-beta', '1.0.0'], '>=1.0.0 <=1.0.1', '1.0.0', False, False],
+    [['1.0.0-beta', '1.1.0-beta', '1.0.0'], '>=1.0.0 <=1.0.1', '1.0.0', False, True],
+    [['1.0.0-beta', '1.0.0', '1.0.1', '1.1.0-beta'], '>=1.0.0 <=1.1.0', '1.0.1', False, False],
+    [['1.0.0-beta', '1.0.0', '1.0.1', '1.1.0-beta'], '>=1.0.0 <=1.1.0', '1.1.0-beta', False, True],
+    [['1.0.0-beta', '1.0.0', '1.0.1', '1.1.0-beta'], '>=1.0.0 <1.1.0', '1.0.1', False, False],
+    [['1.0.0-beta', '1.0.0', '1.0.1', '1.1.0-beta'], '>=1.0.0 <1.1.0', '1.0.1', False, True],
+    [['1.0.0-beta', '1.1.0-beta'], '>=1.0.0 <=1.1.0', None, False, False],
+    [['1.0.0-beta', '1.1.0-beta'], '>=1.0.0 <=1.1.0', '1.1.0-beta', False, True],
+
+    # explicitly specifying range begin/end with prerelease
+    [['1.0.0-beta', '1.1.0-beta', '1.0.0'], '>=1.0.0-0 <1.0.1', '1.0.0', False, True],
+    [['1.0.0-beta', '1.1.0-beta', '1.1.0'], '>=1.0.0-0 <1.1.0-0', '1.0.0-beta', False, True],
+    [['1.0.0-beta', '1.0.0', '1.0.1', '1.1.0-beta', '1.1.0'], '>=1.0.0-0 <1.1.0-0', '1.0.1', False, False],
+    [['1.0.0-beta', '1.0.0', '1.0.1', '1.1.0-beta', '1.1.0'], '>=1.0.0-0 <1.1.0-0', '1.0.1', False, True],
+    [['1.0.0-beta', '1.1.0-beta'], '>=1.0.0-0 <1.1.0', '1.0.0-beta', False, True],
+
+    [['1.0.0-pre'],   '1.0.x', '1.0.0-pre', False, True],
+    [['1.0.0-pre'], '>=1.0.x', '1.0.0-pre', False, True],
+
+    [['1.1.0-pre'], '>=1.0.0 <1.1.1-z', None, False, False],
+    # Note: This test would fail with `node-semver`, see also https://github.com/npm/node-semver/issues/317
+    [['1.1.1-pre'], '>=1.0.0 <1.1.1-z', '1.1.1-pre', False, False],
+    # While this one would succeed with `node-semver`
+#    [['1.0.0-pre'], '>=1.0.0 <=1.1.0', None, False, True],
 
 ]
 


### PR DESCRIPTION
This merge request fixes a bunch of issues with 'range checks'. It therefore adds several tests along with a proposed fix.

I compared the behavior with node-semver and by this PR, we'd come much closer to its behavior.

I'm not sure how the version of this Python module should be handled: While it's a bugfix, it certainly may affect existing software out there... such as Conan packages. Therefore, an increase in major should be considered.

See also the issue /issues/37