### PR TITLE
Fix erroneous parsing of $ component version numbers

### DIFF
--- a/semver/__init__.py
+++ b/semver/__init__.py
@@ -67,6 +67,11 @@ src[NUMERICIDENTIFIERLOOSE] = '[0-9]+'
 NONNUMERICIDENTIFIER = R()
 src[NONNUMERICIDENTIFIER] = '\\d*[a-zA-Z-][a-zA-Z0-9-]*'
 
+# A non-numeric identifier not beginning with a number
+
+NONNUMERICIDENTIFIERBEGINNONNUMBER = R()
+src[NONNUMERICIDENTIFIERBEGINNONNUMBER] = '[a-zA-Z-][a-zA-Z0-9-]*'
+
 # ## Main Version
 # Three dot-separated numeric identifiers.
 
@@ -102,7 +107,8 @@ src[PRERELEASE] = ('(?:-(' + src[PRERELEASEIDENTIFIER] +
                    '(?:\\.' + src[PRERELEASEIDENTIFIER] + ')*))')
 
 PRERELEASELOOSE = R()
-src[PRERELEASELOOSE] = ('(?:-?(' + src[PRERELEASEIDENTIFIERLOOSE] +
+src[PRERELEASELOOSE] = ('(?:-?((?:(?<=-)' + src[PRERELEASEIDENTIFIERLOOSE] +
+                        '|' + src[NONNUMERICIDENTIFIERBEGINNONNUMBER] + ')'
                         '(?:\\.' + src[PRERELEASEIDENTIFIERLOOSE] + ')*))')
 
 # ## Build Metadata Identifier

--- a/semver/tests/test_for_4digit.py
+++ b/semver/tests/test_for_4digit.py
@@ -93,6 +93,16 @@ cands = [
             "micro_versions": [2, 2],
         }
     ),
+    (
+        "4.1.33.2", True, {
+            "major": 4,
+            "minor": 1,
+            "patch": 33,
+            "prerelease": [],
+            "build": [],
+            "micro_versions": [2],
+        }
+    ),
 ]
 
 


### PR DESCRIPTION
Fixes parsing of four(or more)-component version numbers when the third component has multiple digits.

Previously version 1.2.33.4 was parsed as 1.2.3-3.4