### PR TITLE
Handle invalid versions in valid()

### DIFF
--- a/nodesemver/__init__.py
+++ b/nodesemver/__init__.py
@@ -275,7 +275,7 @@ def parse(version, loose):
 
 def valid(version, loose):
     v = parse(version, loose)
-    if v.version:
+    if v and v.version:
         return v
     else:
         return None

--- a/nodesemver/tests/test_regression.py
+++ b/nodesemver/tests/test_regression.py
@@ -14,3 +14,13 @@ def test_it(op, wanted, cands):
     from nodesemver import max_satisfying
     got = max_satisfying(cands, op, loose=True)
     assert got == wanted
+
+
+@pytest.mark.parametrize("version, loose", [
+    # https://github.com/podhmo/python-node-semver/issues/42
+    ("NOT VALID", False),
+    ("NOT VALID", True),
+])
+def test_valid_returns_none_for_unparseable_versions(version, loose):
+    from nodesemver import valid
+    assert valid(version, loose) is None


### PR DESCRIPTION
## Summary
- return `None` from `valid()` when `parse()` cannot build a semantic version
- add regression coverage for invalid version strings in strict and loose modes

Fixes #42.

## Tests
- `venv/bin/python -m pytest nodesemver/tests/test_regression.py -q`
- `venv/bin/python -m pytest -q`
